### PR TITLE
Fix typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ usage: ./setup.sh <model> <sensor> [-dt | --disable-temp] [-du | --disable-utils
 ```
 
 Available supported models:
-- `sk620`
-- `sk500s`
+- `ak620`
+- `ak500s`
 
 ### Step-by-Step Guide
 


### PR DESCRIPTION
Supported model names didn't match the script options